### PR TITLE
Update requirements.txt for tweepy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
-tweepy
+tweepy==3.9.0
 pillow
 colorama
 datetime


### PR DESCRIPTION
more successful tweepy usage with 3.9.0 (that i found)
old usage of tweepy is supported in 3.9.0 as it is no longer supported with the latest (media stuff)